### PR TITLE
fixes for v1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "syntheval"
-version = "1.7.0"
+version = "1.7.1"
 authors = [
   { name="Anton D. Lautrup"},
   { name="Tobias Hyrup"},

--- a/src/syntheval/metrics/privacy/metric_MIA_classification.py
+++ b/src/syntheval/metrics/privacy/metric_MIA_classification.py
@@ -2,9 +2,11 @@
 # Author: Tobias Hyrup
 # Date: 2023-10-30
 
+import warnings
+
 import numpy as np
 import pandas as pd
-from logging import warning
+
 from syntheval.metrics.core.metric import MetricClass
 from lightgbm import LGBMClassifier
 from sklearn.metrics import precision_score, recall_score, f1_score
@@ -59,9 +61,7 @@ class MIAClassifier(MetricClass):
             raise ValueError("Membership inference attack metric did not run, holdout data was not supplied!")
         else:
             if len(self.real_data) < len(self.hout_data) // 2:
-                    warning(
-                        "The holdout data is more than double the size of the real data. The holdout data will be downsampled to match the size of the real data. real size: %s, holdout size: %s", len(self.real_data), len(self.hout_data)
-                    )
+                warnings.warn(f"The holdout data is more than double the size of the real data. The holdout data will be downsampled to match the size of the real data. real size: {len(self.real_data)}, holdout size: {len(self.hout_data)}")
             # One-hot encode. All data is combined to ensure consitent encoding
             combined_data = pd.concat(
                 [self.real_data, self.synt_data, self.hout_data], ignore_index=True
@@ -87,7 +87,10 @@ class MIAClassifier(MetricClass):
             }
             for _ in range(num_eval_iter):
                 hout_train, hout_test = train_test_split(hout, test_size=0.25)
-                syn_samples = syn.sample(n=len(hout_train))
+                if len(syn) < len(hout_train):
+                    syn_samples = syn.sample(n=len(hout_train), replace=True)
+                else:
+                    syn_samples = syn.sample(n=len(hout_train))
 
                 # Create training data consisting of synthetic and holdout data
                 X_train = pd.concat([syn_samples, hout_train], axis=0, ignore_index=True)

--- a/src/syntheval/metrics/utility/metric_feature_importance_overlap.py
+++ b/src/syntheval/metrics/utility/metric_feature_importance_overlap.py
@@ -162,9 +162,13 @@ class FeatureImportanceOverlap(MetricClass):
                         else:
                             continue
             else:
-                self.results['fio_diff'] = result_rows[0]['mae_importance']
-                self.results['fio_diff_weighted'] = result_rows[0]['mae_weighted_importance']
-                self.results = {'fio_' + key: result_rows[0][key] for key in result_rows[0] if key.startswith('top_')}
+                self.results['fio_diff'] = float(result_rows[0]['mae_importance'])
+                self.results['fio_diff_weighted'] = float(result_rows[0]['mae_weighted_importance'])
+                for p in compare_percentages:
+                    if 'top_'+str(int(p*100))+ '%' in result_rows[0]:
+                        self.results[f'fio_top_{int(p*100)}%'] = float(result_rows[0]['top_'+str(int(p*100))+ '%'])
+                    else:
+                        continue
         return self.results
 
     def format_output(self) -> List[tuple]:

--- a/src/syntheval/metrics/utility/metric_principal_component_analysis.py
+++ b/src/syntheval/metrics/utility/metric_principal_component_analysis.py
@@ -2,6 +2,7 @@
 # Author: Anton D. Lautrup
 # Date: 23-08-2023
 
+import warnings
 import pandas as pd
 import numpy as np
 
@@ -80,8 +81,14 @@ class PrincipalComponentAnalysis(MetricClass):
             else:
                 select_cols = self.num_cols
 
+            if len(self.real_data) < len(select_cols):
+                warnings.warn("Calculating the pca metric with fewer rows than columns may not be reliable!")
+                metric_comps = min(len(self.real_data), len(select_cols))
+            else:
+                metric_comps = len(select_cols)
+            
             # Get PCA metrics and projections
-            res, _, _ = PCAMetric(self.real_data[select_cols], self.synt_data[select_cols], preprocess=preprocess)
+            res, _, _ = PCAMetric(self.real_data[select_cols], self.synt_data[select_cols], num_components = metric_comps, preprocess=preprocess)
 
             self.results = {'exp_var_diff': float(res['exp_var_diff']), 'comp_angle_diff': float(res['comp_angle_diff'])}
 

--- a/src/syntheval/syntheval.py
+++ b/src/syntheval/syntheval.py
@@ -7,6 +7,8 @@ import json
 import glob
 import time
 import threading
+import warnings
+import io
 
 import asyncio
 import traceback
@@ -31,15 +33,24 @@ def _has_not_slash_backslash_or_dot(input_string):
     return not ('/' in input_string or '\\' in input_string or '.' in input_string)
 
 def _metric_work(method, evaluation_config, worker_args):
-    try:
-        M = method(**worker_args)
-        raw_result = M.evaluate(**evaluation_config)
-        formatted_output = M.format_output()
-        key_result = M.normalize_output()
-        error = None
-    except Exception as e:
-        raw_result, formatted_output, key_result, error = None, None, None, e
-    return raw_result, formatted_output, key_result, error
+    warnings_list = []
+    
+    # Capture warnings during metric evaluation
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        try:
+            M = method(**worker_args)
+            raw_result = M.evaluate(**evaluation_config)
+            formatted_output = M.format_output()
+            key_result = M.normalize_output()
+            error = None
+        except Exception as e:
+            raw_result, formatted_output, key_result, error = None, None, None, e
+        
+        # Store any warnings that were raised
+        warnings_list = [str(warning.message) for warning in w]
+    
+    return raw_result, formatted_output, key_result, error, warnings_list
 
 async def _run_metric_with_timeout(method, evaluation_config, worker_args, timeout):
     return await asyncio.wait_for(asyncio.to_thread(_metric_work, method, evaluation_config, worker_args), timeout=timeout)
@@ -103,7 +114,8 @@ class SynthEval():
                  verbose: bool = True,
                  enable_plots: bool = True,
                  console: Literal['rich', 'ascii', 'off'] = 'rich',
-                 timeout: int = None
+                 timeout: int = None,
+                 show_warnings: bool = True
         ) -> None:
         """Primary object for accessing the SynthEval evaluation framework. Create with the real data used for training 
         and use either evaluate of benchmark methods for evaluating synthetic datasets.
@@ -119,9 +131,11 @@ class SynthEval():
             enable_plots        : flag for enabling plot generation.
             console             : type of console output to use ('rich', 'ascii', 'off').
             timeout             : time in seconds after which a metric evaluation will be interrupted and skipped. Default is None (no timeout).
+            show_warnings       : flag for displaying warnings from metrics in the console. Default is True.
         """
         self.verbose = verbose
         self.enable_plots = enable_plots
+        self.show_warnings = show_warnings
 
         if in_notebook() and console == 'rich':
             self.console = 'ascii'
@@ -260,7 +274,7 @@ class SynthEval():
                 console.show_cursor(True)
                 for method in methods_loaded:
                     try:
-                        raw, formatted_output, key_result, error = _run_coroutine_sync(
+                        raw, formatted_output, key_result, error, warnings_list = _run_coroutine_sync(
                             _run_metric_with_timeout(
                                 loaded_metrics[method], evaluation_config[method], worker_args, self.timeout
                             )
@@ -269,6 +283,10 @@ class SynthEval():
                             raise error
                         raw_results[method] = raw
                         key_results = _add_key_results(key_results, key_result)
+
+                        if self.show_warnings and warnings_list:
+                            for warning_msg in warnings_list:
+                                co.add_error_message(message=f"WARNING ({method}): {warning_msg}")
 
                         if formatted_output is not None:
                             co.update_result_table_rows(method, formatted_output)
@@ -296,7 +314,7 @@ class SynthEval():
             for method in pbar:
                 pbar.set_description(f'Syntheval: {method}')
                 try:                    
-                    raw, formatted_output, key_result, error = _run_coroutine_sync(
+                    raw, formatted_output, key_result, error, warnings_list = _run_coroutine_sync(
                             _run_metric_with_timeout(
                                 loaded_metrics[method], evaluation_config[method], worker_args, self.timeout
                             )
@@ -305,6 +323,10 @@ class SynthEval():
                         raise error
                     raw_results[method] = raw
                     key_results = _add_key_results(key_results, key_result)
+                    
+                    if self.show_warnings and warnings_list:
+                        for warning_msg in warnings_list:
+                            print(f"WARNING ({method}): {warning_msg}")
                     
                     if formatted_output is not None:
                             co.add_results_to_tables(formatted_output)
@@ -322,7 +344,7 @@ class SynthEval():
             timed_out_methods = [] 
             for method in methods_loaded:
                 try:
-                    raw, formatted_output, key_result, error = _run_coroutine_sync(
+                    raw, formatted_output, key_result, error, warnings_list = _run_coroutine_sync(
                             _run_metric_with_timeout(
                                 loaded_metrics[method], evaluation_config[method], worker_args, self.timeout
                             )
@@ -331,6 +353,10 @@ class SynthEval():
                         raise error
                     raw_results[method] = raw
                     key_results = _add_key_results(key_results, key_result)
+                    
+                    if self.show_warnings and warnings_list:
+                        for warning_msg in warnings_list:
+                            print(f"WARNING ({method}): {warning_msg}")
                 except asyncio.TimeoutError:
                     timed_out_methods.append(method)
                     continue


### PR DESCRIPTION
**Improvements:**
- Rich console mode no longer suppresses warnings, and warnings are now handled in a nicer way and can be toggled with SynthEval's new `show_warnings` argument. 

**Bug fixes:**
- The FIO metric would fail when only a single outcome variable was provided, due to a mistaken variable reassignment.
- The MIA metric would fail when the size of the synthetic data was less than the size of the holdout data. We made a catch because keeping a large holdout set may be intended.
- PCA is not really meant to work with fewer rows than columns; for the PCA metric, this would cause an error from sklearn. We made a catch and now produce a warning when this is the case. 